### PR TITLE
Only hide for older version of DBM

### DIFF
--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6059,8 +6059,10 @@ Private.event_prototypes = {
 
 };
 
-Private.event_prototypes["DBM Announce"] = nil
-Private.event_prototypes["DBM Timer"] = nil
+if (DBM and tonumber(DBM.Revision) < 7003) then 
+  Private.event_prototypes["DBM Announce"] = nil
+  Private.event_prototypes["DBM Timer"] = nil
+end
 Private.event_prototypes["BigWigs Message"] = nil
 Private.event_prototypes["BigWigs Timer"] = nil
 

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -6059,7 +6059,7 @@ Private.event_prototypes = {
 
 };
 
-if (DBM and tonumber(DBM.Revision) < 7003) then 
+if (DBM and tonumber(DBM.Revision) < 7003) then
   Private.event_prototypes["DBM Announce"] = nil
   Private.event_prototypes["DBM Timer"] = nil
 end


### PR DESCRIPTION
Newer backports of DBM that have correct fireEvent in their core.lua should be able to use these triggers