### PR TITLE
Fixes for SwingTimer as suggested by Cheeta

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -1515,7 +1515,7 @@ do
             event = "SWING_TIMER_CHANGE";
             mainTimer = timer:ScheduleTimer(swingEnd, mainSpeed, "main");
           else
-            timer:CancelTimer(mainTimer, true);
+            timer:CancelTimer(offTimer, true);
             lastSwingOff = currentTime;
             swingDurationOff = offSpeed;
             event = "SWING_TIMER_CHANGE";
@@ -1554,7 +1554,7 @@ do
           timer:CancelTimer(mainTimer)
           local multiplier = mainSpeedNew / mainSpeed
           local timeLeft = (lastSwingMain + swingDurationMain - GetTime()) * multiplier
-          swingDurationMain = mainSpeedNew
+          swingDurationMain = GetTime()-lastSwingMain + timeLeft
           mainTimer = timer:ScheduleTimer(swingEnd, timeLeft, "main")
           WeakAuras.ScanEvents("SWING_TIMER_CHANGE")
         end
@@ -1562,9 +1562,9 @@ do
       if lastSwingOff then
         if offSpeedNew ~= offSpeed then
           timer:CancelTimer(offTimer)
-          local multiplier = offSpeedNew / mainSpeed
+          local multiplier = offSpeedNew / offSpeed
           local timeLeft = (lastSwingOff + swingDurationOff - GetTime()) * multiplier
-          swingDurationOff = offSpeedNew
+          swingDurationOff = GetTime() - lastSwingOff + timeLeft
           offTimer = timer:ScheduleTimer(swingEnd, timeLeft, "off")
           WeakAuras.ScanEvents("SWING_TIMER_CHANGE")
         end


### PR DESCRIPTION
As suggested on discord in the #wa-support channel. The code for handling Swing Timers have issues which are address as followed by Cheeta's suggestions by the post (https://discord.com/channels/259362419372064778/740945052989128724/855632779035410432):

> 04:19] Cheeta: I have already tried a few SwingTimer for MH and OH and the one from the current WA version was by far the best (reacts to attack speed changes like Flurry talent). By the way, cant recommend the one from Elvui at all. 
However, there are still a few bugs in the code that I had changed myself (no idea about Github or how to make a pull request there).
If you are interested you can try to reproduce these changes and test again:

> GenericTrigger.lua:
Typo in  line 1518: (mostly it should solve the problem that the MH swingtimer randomly disappears )
timer:CancelTimer(mainTimer, true);
to 
timer:CancelTimer(offTimer, true);

> calculate more accurate duration after attack speed changes in line 1557:
swingDurationMain = mainSpeedNew
to 
swingDurationMain = GetTime()-lastSwingMain + timeLeft

> and line 1567:
swingDurationOff = offSpeedNew
to 
swingDurationOff = GetTime() - lastSwingOff + timeLeft

> And last a Typo again in line 1565:
local multiplier = offSpeedNew / mainSpeed
change to
local multiplier = offSpeedNew / offSpeed


Due to their unfamiliarity with Git I've made the pull request for them.