### PR TITLE
Add DBM Phase triggers

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2453,6 +2453,7 @@ do
   local bars = {}
   local nextExpire -- time of next expiring timer
   local recheckTimer -- handle of timer
+  local currentStage = 0
 
   local function dbmRecheckTimers()
     local now = GetTime()
@@ -2542,6 +2543,10 @@ do
         end
       end
       WeakAuras.ScanEvents("DBM_TimerUpdate", id)
+    elseif event == "DBM_SetStage" then
+      local mod, modId, stage = ...
+      currentStage = stage
+      WeakAuras.ScanEvents("DBM_SetStage", ...)
     else -- DBM_Announce
       WeakAuras.ScanEvents(event, ...)
     end
@@ -2581,6 +2586,10 @@ do
       return false
     end
     return true
+  end
+
+  function WeakAuras.GetDBMStage()
+    return currentStage
   end
 
   function WeakAuras.GetDBMTimerById(id)

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -3115,6 +3115,30 @@ Private.event_prototypes = {
     timedrequired = true
   },
   -- DBM events
+  ["DBM Stage"] = {
+    type = "addons",
+    events = {},
+    internal_events = {
+      "DBM_SetStage"
+    },
+    name = L["DBM Stage"],
+    init = function(trigger)
+      WeakAuras.RegisterDBMCallback("DBM_SetStage");
+      return ""
+    end,
+    args = {
+      {
+        name = "stage",
+        init = "WeakAuras.GetDBMStage()",
+        display = L["Stage"],
+        type = "number",
+        conditionType = "number",
+        store = true,
+      }
+    },
+    automaticrequired = true,
+    statesParameter = "one",
+  },
   ["DBM Announce"] = {
     type = "addons",
     events = {},
@@ -6059,9 +6083,12 @@ Private.event_prototypes = {
 
 };
 
-if not (DBM and (tonumber(DBM.Revision) or 0) >= 7003) then
+if not (DBM and DBM.ReleaseRevision >= 7003) then
   Private.event_prototypes["DBM Announce"] = nil
   Private.event_prototypes["DBM Timer"] = nil
+end
+if not (DBM and DBM.ReleaseRevision >= 7005) then
+  Private.event_prototypes["DBM Stage"] = nil
 end
 Private.event_prototypes["BigWigs Message"] = nil
 Private.event_prototypes["BigWigs Timer"] = nil


### PR DESCRIPTION
- Callback can be used by external addons like Weakauras in its triggers.
- Fire stage callback on variable recovery
- Added public facing stage api, that allows for mods or Weakauras request current stage a mod is in (if applicable) for either specific mod by mod id OR by simply doing request without modId, and having DBM just give a return for first mod in combat table
- Boss modules migrated to use newly added SetStage function

Custom DBM commits with appropriate ReleaseRevision bump to 7005 to ensure DBM is compatible:

https://github.com/Zidras/DBM-Icecrown/commit/ff3a3a27502c73ed5686029bcca3be3afd8a459f

https://github.com/Barsoomx/DBM-wowcircle/commit/6388338048ad1916f2753995f02057889d3fc20b