### PR TITLE
fix Enchantment Trigger on Login

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -2908,6 +2908,7 @@ do
     if not(tenchFrame) then
       tenchFrame = CreateFrame("Frame");
       tenchFrame:RegisterEvent("UNIT_INVENTORY_CHANGED");
+      tenchFrame:RegisterEvent("PLAYER_ENTERING_WORLD");
 
       tenchTip = WeakAuras.GetHiddenTooltip();
 
@@ -2962,7 +2963,7 @@ do
 
       tenchFrame:SetScript("OnEvent", function(self, event, arg1)
         Private.StartProfileSystem("generictrigger");
-        if (event == "UNIT_INVENTORY_CHANGED" and arg1 == "player") then
+        if (event == "UNIT_INVENTORY_CHANGED" and arg1 == "player") or event == "PLAYER_ENTERING_WORLD" then
           timer:ScheduleTimer(tenchUpdate, 0.1);
         end
         Private.StopProfileSystem("generictrigger");


### PR DESCRIPTION
Event "UNIT_INVENTORY_CHANGED" triggers on login, but no further gear information is loaded at that time. This means that it is recognised whether an enchantment is present, but not which one it is (the code specifies "Unknown" as its name). The name is then only updated when event "UNIT_INVENTORY_CHANGED" is sent again.