### PR TITLE
update spell cache to latest version

### DIFF
--- a/WeakAurasOptions/Cache.lua
+++ b/WeakAurasOptions/Cache.lua
@@ -31,22 +31,24 @@ function spellCache.Build()
   local co = coroutine.create(function()
     local id = 0
     local misses = 0
-
-    while misses < 53000 do
+    while misses < 50000 do
       id = id + 1
       local name, _, icon = GetSpellInfo(id)
 
-      if(icon == 136243) then -- 136243 is the a gear icon, we can ignore those spells
+      if(icon and icon:lower() == "interface\\icons\\trade_engineering") then -- 136243 is the a gear icon, we can ignore those spells
         misses = 0;
-      elseif name and name ~= "" then
+      elseif name and name ~= "" and icon then
         cache[name] = cache[name] or {}
-        cache[name].spells = cache[name].spells or {}
-        cache[name].spells[id] = icon
+
+        if not cache[name].spells or cache[name].spells == "" then
+          cache[name].spells = id .. "=" .. icon
+        else
+          cache[name].spells = cache[name].spells .. "," .. id .. "=" .. icon
+        end
         misses = 0
       else
         misses = misses + 1
       end
-
       coroutine.yield()
     end
 
@@ -56,8 +58,11 @@ function spellCache.Build()
         local id,name,_,_,_,_,_,_,_,iconID = GetAchievementInfo(category, i)
         if name and iconID then
           cache[name] = cache[name] or {}
-          cache[name].achievements = cache[name].achievements or {}
-          cache[name].achievements[id] = iconID
+          if not cache[name].achievements or cache[name].achievements == "" then
+            cache[name].achievements = id .. "=" .. iconID
+          else
+            cache[name].achievements = cache[name].achievements .. "," .. id .. "=" .. iconID
+          end
         end
       end
       coroutine.yield()
@@ -91,16 +96,18 @@ function spellCache.GetIcon(name)
     local bestMatch = nil
     if (icons) then
       if (icons.spells) then
-        for spellId, icon in pairs(icons.spells) do
-          if not bestMatch or (type(spellId) == "number" and IsSpellKnown(spellId)) then
-            bestMatch = spellId
+        for spell, icon in icons.spells:gmatch("(%d+)=([^,]+)") do
+          local spellId = tonumber(spell)
+
+          if not bestMatch or (spellId and IsSpellKnown(spellId)) then
+            bestMatch = tonumber(icon)
           end
         end
       end
     end
 
-    bestIcon[name] = bestMatch and icons.spells[bestMatch];
-    return bestIcon[name];
+    bestIcon[name] = bestMatch
+    return bestIcon[name]
   else
     error("spellCache has not been loaded. Call WeakAuras.spellCache.Load(...) first.")
   end
@@ -108,21 +115,31 @@ end
 
 function spellCache.GetSpellsMatching(name)
   if cache[name] then
-    return cache[name].spells
+    if cache[name].spells then
+      local result = {}
+      for spell, icon in cache[name].spells:gmatch("(%d+)=([^,]+)") do
+        local spellId = tonumber(spell)
+        local iconId = tonumber(icon)
+        result[spellId] = icon
+      end
+      return result
+    end
   end
 end
 
 function spellCache.AddIcon(name, id, icon)
-  if cache then
-    if name then
-      cache[name] = cache[name] or {}
-      cache[name].spells = cache[name].spells or {}
-      if id and icon then
-        cache[name].spells[id] = icon
-      end
-    end
-  else
+  if not cache then
     error("spellCache has not been loaded. Call WeakAuras.spellCache.Load(...) first.")
+    return
+  end
+
+  if name and id and icon then
+    cache[name] = cache[name] or {}
+    if not cache[name].spells or cache[name].spells == "" then
+      cache[name].spells = id .. "=" .. icon
+    else
+      cache[name].spells = cache[name].spells .. "," .. id .. "=" .. icon
+    end
   end
 end
 
@@ -147,11 +164,12 @@ function spellCache.Load(data)
     num = num + 1;
   end
 
-  if(num < 39000 or metaData.locale ~= locale or metaData.build ~= build or metaData.version ~= version or not metaData.spellCacheAchivements) then
+  if(num < 39000 or metaData.locale ~= locale or metaData.build ~= build or metaData.version ~= version or not metaData.spellCacheStrings) then
     metaData.build = build;
     metaData.locale = locale;
     metaData.version = version;
     metaData.spellCacheAchivements = true
+    metaData.spellCacheStrings = true
     metaData.needsRebuild = true
     wipe(cache)
   end

--- a/WeakAurasOptions/OptionsFrames/IconPicker.lua
+++ b/WeakAurasOptions/OptionsFrames/IconPicker.lua
@@ -66,7 +66,7 @@ local function ConstructIconPicker(frame)
       for name, icons in pairs(spellCache.Get()) do
         if(name:lower():find(subname, 1, true)) then
           if icons.spells then
-            for spellId, icon in pairs(icons.spells) do
+            for spell, icon in icons.spells:gmatch("(%d+)=([^,]+)") do
               if (not usedIcons[icon]) then
                 AddButton(name, icon)
                 num = num + 1;
@@ -76,7 +76,7 @@ local function ConstructIconPicker(frame)
               end
             end
           elseif icons.achievements then
-            for _, icon in pairs(icons.achievements) do
+            for _, icon in icons.achievements:gmatch("(%d+)=([^,]+)") do
               if (not usedIcons[icon]) then
                 AddButton(name, icon)
                 num = num + 1;


### PR DESCRIPTION
Backport spell cache to latest version. I checked everything, everything works. In short, the structure of the data recording in the WeakAurasOptionsSaved.spellCache table has been changed.

But, if suddenly you do not want to apply these changes for some reason, then correct the next line
https://github.com/Bunny67/WeakAuras-WotLK/blob/536db3089da063336c7fffac5880a3682e995949/WeakAurasOptions/Cache.lua#L39
for
`if(icon and icon:lower() == "interface\\icons\\trade_engineering") then -- 136243 is the a gear icon, we can ignore those spells`