### PR TITLE
fix imports from new wa versions

### DIFF
--- a/WeakAuras/GenericTrigger.lua
+++ b/WeakAuras/GenericTrigger.lua
@@ -211,14 +211,18 @@ function ConstructTest(trigger, arg)
       test = "("..arg.test:format(tostring(trigger[name]) or "")..")";
     elseif(arg.type == "longstring" and trigger[name.."_operator"]) then
       test = TestForLongString(trigger, arg);
-    elseif (arg.type == "string" or arg.type == "select" or arg.type == "item") then
+    elseif (arg.type == "string" or arg.type == "select" or arg.type == "item") and not (type(trigger[name]) == "table") then
       test = "(".. name .." and "..name.."==" ..(number or "\""..(trigger[name] or "").."\"")..")";
     else
-      if(type(trigger[name]) == "table") then
-        trigger[name] = "error";
-      end
-      -- number
-      test = "(".. name .." and "..name..(trigger[name.."_operator"] or "==")..(number or "\""..(trigger[name] or "").."\"")..")";
+      -- if (type(trigger[name]) == "table") or type(trigger[name.."_operator"]) == "table" then
+        -- 3.4.0 auras fix
+        if (type(trigger[name]) == "table") then
+          trigger[name] = trigger[name][1] or "error";
+        end
+        if (type(trigger[name.."_operator"]) == "table") then
+          trigger[name.."_operator"] = trigger[name.."_operator"][1] or "error";
+        end
+      test = "(".. name .." and "..name..(trigger[name.."_operator"] or "==")..(number or ("\""..(trigger[name])) or ("".."\""))..")";
     end
   end
 


### PR DESCRIPTION
this pull fixes the problem with importing auras from new versions, previously it broke the addon in the middle of import, but now you can import it without any problems (it does not solve problems with new client functions, if the aura is written in code or part of the code, the code will need to be fixed separately)
some tests
import https://wago.io/LuxthosHunterWrath
![image](https://github.com/Bunny67/WeakAuras-WotLK/assets/84588274/58f3bd71-306b-4b9a-b3da-6c7b432c3a89)
![image](https://github.com/Bunny67/WeakAuras-WotLK/assets/84588274/4ac6d886-9d4c-4d59-a951-0d111819bd83)
import https://wago.io/EqZ6HNPJe
![image](https://github.com/Bunny67/WeakAuras-WotLK/assets/84588274/c83e4fae-8b02-47de-8306-d5121a180261)
![image](https://github.com/Bunny67/WeakAuras-WotLK/assets/84588274/5e44f87d-e0bd-4e3e-8207-34f4fc869769)

the only problem that remains is the problem with the icons, in new versions they use the id, they immediately need a path, I didn’t find how to do compatibility because the ids go to more than 200k and 335 doesn’t have these abilities

https://wago.io/TemsWotlkDungeons
![image](https://github.com/Bunny67/WeakAuras-WotLK/assets/84588274/06bd777d-9523-4de9-b697-1bf594e66551)

![image](https://github.com/Bunny67/WeakAuras-WotLK/assets/84588274/782f6ecf-0502-4d8b-90ab-e85905eca923)
![image](https://github.com/Bunny67/WeakAuras-WotLK/assets/84588274/1b6e7a1f-2d4f-4217-b7c0-6d9497295bba)

