### PR TITLE
WeakAuras.lua: Fixed FrameStrata problems

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1014,6 +1014,7 @@ end
 local frame = CreateFrame("FRAME", "WeakAurasFrame", UIParent);
 WeakAuras.frames["WeakAuras Main Frame"] = frame;
 frame:SetAllPoints(UIParent);
+frame:SetFrameStrata("BACKGROUND");
 
 local loadedFrame = CreateFrame("FRAME");
 WeakAuras.frames["Addon Initialization Handler"] = loadedFrame;


### PR DESCRIPTION
Some interface elements (Blizzard and Addon GUI elements) have been having issues (partially not showing up / not interactable) and after doctoring around and investigating the /framestack some bright players have found a very simple solution (setting the FrameStrata of "WeakAuras Main Frame" to "BACKGROUND").