### PR TITLE
Adds 'subzone' string load option for auras.

### DIFF
--- a/WeakAuras/Locales/deDE.lua
+++ b/WeakAuras/Locales/deDE.lua
@@ -1540,4 +1540,5 @@ L["Zone ID(s)"] = "Zone ID(s)"
 L["Zone Name"] = "Gebietsname"
 L["Zoom"] = "Zoom"
 L["Zul'Gurub"] = "Zul'Gurub"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/enUS.lua
+++ b/WeakAuras/Locales/enUS.lua
@@ -1059,7 +1059,7 @@ L["Zone ID(s)"] = "Zone ID(s)"
 L["Zone Name"] = "Zone Name"
 L["Zoom"] = "Zoom"
 L["Zul'Gurub"] = "Zul'Gurub"
-
+L["Subzone Name"] = "Subzone Name"
 
 -- Make missing translations available
 setmetatable(WeakAuras.L, {__index = function(self, key)

--- a/WeakAuras/Locales/esES.lua
+++ b/WeakAuras/Locales/esES.lua
@@ -1716,4 +1716,5 @@ L["Zone Name"] = "Zone Name"
 L["Zoom"] = "Zoom"
 --[[Translation missing --]]
 L["Zul'Gurub"] = "Zul'Gurub"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/esMX.lua
+++ b/WeakAuras/Locales/esMX.lua
@@ -1649,4 +1649,5 @@ L["Zone Name"] = "Zone Name"
 L["Zoom"] = "Zoom"
 --[[Translation missing --]]
 L["Zul'Gurub"] = "Zul'Gurub"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/frFR.lua
+++ b/WeakAuras/Locales/frFR.lua
@@ -1402,4 +1402,5 @@ L["Zone Name"] = "Nom de la Zone"
 L["Zoom"] = "Zoom"
 --[[Translation missing --]]
 L["Zul'Gurub"] = "Zul'Gurub"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/itIT.lua
+++ b/WeakAuras/Locales/itIT.lua
@@ -1937,4 +1937,5 @@ L["Zone Name"] = "Zone Name"
 L["Zoom"] = "Zoom"
 --[[Translation missing --]]
 L["Zul'Gurub"] = "Zul'Gurub"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/koKR.lua
+++ b/WeakAuras/Locales/koKR.lua
@@ -1229,4 +1229,5 @@ L["Zone ID(s)"] = "지역 ID"
 L["Zone Name"] = "지역 이름"
 L["Zoom"] = "확대"
 L["Zul'Gurub"] = "줄구룹"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/ptBR.lua
+++ b/WeakAuras/Locales/ptBR.lua
@@ -1751,4 +1751,5 @@ L["Zone Name"] = "Zone Name"
 L["Zoom"] = "Zoom"
 --[[Translation missing --]]
 L["Zul'Gurub"] = "Zul'Gurub"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/ruRU.lua
+++ b/WeakAuras/Locales/ruRU.lua
@@ -1179,4 +1179,5 @@ L["Zone ID(s)"] = "ID игровой зоны"
 L["Zone Name"] = "Название игровой зоны"
 L["Zoom"] = "Масштаб"
 L["Zul'Gurub"] = "Зул'Гуруб"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/zhCN.lua
+++ b/WeakAuras/Locales/zhCN.lua
@@ -1070,4 +1070,5 @@ L["Zone ID(s)"] = "单个/多个区域 ID"
 L["Zone Name"] = "区域名称"
 L["Zoom"] = "缩放"
 L["Zul'Gurub"] = "祖尔格拉布"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Locales/zhTW.lua
+++ b/WeakAuras/Locales/zhTW.lua
@@ -1072,4 +1072,5 @@ L["Zone ID(s)"] = "區域 ID"
 L["Zone Name"] = "區域名稱"
 L["Zoom"] = "縮放"
 L["Zul'Gurub"] = "祖爾格拉布"
-
+--[[Translation missing --]]
+L["Subzone Name"] = "Subzone Name"

--- a/WeakAuras/Prototypes.lua
+++ b/WeakAuras/Prototypes.lua
@@ -924,6 +924,15 @@ Private.load_prototype = {
 	  end
     },
     {
+      name = "subzone",
+      display = L["Subzone Name"],
+      type = "string",
+      init = "arg",
+      test = "WeakAuras.CheckString(%q, subzone)",
+      events = { "ZONE_CHANGED", "ZONE_CHANGED_INDOORS", "ZONE_CHANGED_NEW_AREA", "VEHICLE_UPDATE" },
+      desc = L["Supports multiple entries, separated by commas"]
+    },
+    {
       name = "size",
       display = L["Instance Size Type"],
       type = "multiselect",

--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -1238,7 +1238,7 @@ local function scanForLoadsImpl(toCheck, event, arg1, ...)
     return
   end
 
-  local player, realm, zone = UnitName("player"), GetRealmName(), GetRealZoneText();
+  local player, realm, zone, subzone = UnitName("player"), GetRealmName(), GetRealZoneText(), GetSubZoneText();
   local faction = UnitFactionGroup("player")
   local zoneId = GetCurrentMapAreaID()
 
@@ -1264,8 +1264,8 @@ local function scanForLoadsImpl(toCheck, event, arg1, ...)
     if (data and not data.controlledChildren) then
       local loadFunc = loadFuncs[id];
       local loadOpt = loadFuncsForOptions[id];
-      shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, size, difficulty);
-      couldBeLoaded =  loadOpt and loadOpt("ScanForLoads_Auras",   inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, size, difficulty);
+      shouldBeLoaded = loadFunc and loadFunc("ScanForLoads_Auras", inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, subzone, size, difficulty);
+      couldBeLoaded =  loadOpt and loadOpt("ScanForLoads_Auras",   inCombat, alive, pvp, vehicle, vehicleUi, group, player, realm, class, faction, playerLevel, zone, zoneId, subzone, size, difficulty);
 
       if(shouldBeLoaded and not loaded[id]) then
         changed = changed + 1;


### PR DESCRIPTION
Adds 'subzone' string load option for auras. Subzone is a text on the minimap. It changes in different parts of a raid allowing WA pack creators to load auras only in specific boss "rooms".
I'm using this feature for a couple months now, and it was added to the 2.4.3 WA repo.